### PR TITLE
feat: Refactor src directory

### DIFF
--- a/src/core/blobURL.js
+++ b/src/core/blobURL.js
@@ -1,0 +1,18 @@
+/**
+ * Create a blob URL from provided buffer and mime type
+ * @param {ArrayBufferLike} buffer
+ * @param {string} mimeType 
+ * @returns {string} blob URL
+ */
+export function createBlobURL(buffer, mimeType) {
+  return URL.createObjectURL(new Blob([buffer], { type: mimeType }));
+}
+
+/**
+ * Dispose a blob URL
+ * @param {string} url 
+ */
+export function disposeBlobURL(url) {
+  // URL.revokeObjectURL is a no-op for non-blob URLs
+  URL.revokeObjectURL(url);
+}

--- a/src/core/configManager.js
+++ b/src/core/configManager.js
@@ -1,0 +1,86 @@
+import { EXECUTION_MODES, MIME_TYPES, RENDERING_BACKENDS } from "./constants";
+import { createBlobURL } from "./blobURL";
+import { stripLeadingDotSlash } from "./stringOps";
+
+/**
+ * Validate provided config
+ * @param {object} config 
+ */
+export function validateConfig(config) {
+  const validRenderings = Object.values(RENDERING_BACKENDS);
+  const validExecModes = Object.values(EXECUTION_MODES);
+  if (config.rendering !== undefined && !validRenderings.includes(config.rendering)) {
+    throw new Error(`Invalid rendering backend: ${config.rendering}. Valid options are: ${validRenderings.join(', ')}`);
+  }
+  if (config.exec !== undefined && !validExecModes.includes(config.exec)) {
+    throw new Error(`Invalid execution mode: ${config.exec}. Valid options are: ${validExecModes.join(', ')}`);
+  }
+}
+
+/**
+ * Normalize provided config based on constraints. WebGPU requires async execution.
+ * @param {object} config 
+ * @returns {object}
+ */
+export function normalizeConfig(config) {
+  if (config?.rendering === RENDERING_BACKENDS.WEBGPU) {
+    if (config?.exec !== EXECUTION_MODES.ASYNC) {
+      console.warn('WebGPU rendering requires async execution mode. Switching exec to "async".');
+      return { ...config, exec: EXECUTION_MODES.ASYNC };
+    }
+  }
+  return config;
+}
+
+/**
+ * Check if two configs are the same. Only rendering and exec are compared.
+ * @param {object} config1 
+ * @param {object} config2 
+ * @returns {boolean}
+ */
+export function isSameConfig(config1, config2) {
+  return config1.rendering === config2.rendering && config1.exec === config2.exec;
+}
+
+/**
+ * Create Emscripten config from provided config
+ * @param {object} config 
+ * @param {{name: string, buffer: ArrayBufferLike}} wasmFile 
+ * @returns {object}
+ */
+export function createEmscriptenConfig(config, wasmFile) {
+  const emscriptenConfig = {};
+  let wasmURL = null;
+  if (wasmFile !== null && wasmFile !== undefined) {
+    emscriptenConfig.locateFile = (fileName) => {
+      const normalizedFileName = stripLeadingDotSlash(fileName);
+      const normalizedTargetName = stripLeadingDotSlash(wasmFile.name);
+      if (normalizedFileName === normalizedTargetName) {
+        wasmURL = createBlobURL(wasmFile.buffer, MIME_TYPES.WASM);
+        return wasmURL;
+      }
+      // Resolve other files relative to this module's URL, not the page URL.
+      return new URL(fileName, import.meta.url).href;
+    };
+  }
+  let userOnRuntimeInitialized = config?.onRuntimeInitialized;
+  emscriptenConfig.onRuntimeInitialized = () => {
+    if (typeof userOnRuntimeInitialized === 'function') {
+      userOnRuntimeInitialized();
+    }
+    // Free the object URL after runtime is initialized
+    if (wasmURL !== null) {
+      URL.revokeObjectURL(wasmURL);
+    }
+  };
+  if (config?.rendering === RENDERING_BACKENDS.WEBGPU) {
+    const userPreRun = Array.isArray(config?.preRun)
+      ? config.preRun
+      : (config?.preRun ? [config.preRun] : []);
+    emscriptenConfig.preRun = [(module) => {
+      module.ENV.VTK_GRAPHICS_BACKEND = 'WEBGPU';
+    },
+    ...userPreRun];
+  }
+  return emscriptenConfig;
+}

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -1,0 +1,25 @@
+export const RENDERING_BACKENDS = Object.freeze({
+  WEBGL: 'webgl',
+  WEBGPU: 'webgpu',
+});
+
+export const EXECUTION_MODES = Object.freeze({
+  SYNC: 'sync',
+  ASYNC: 'async',
+});
+
+export const DEFAULT_WASM_BASE_NAME = 'vtk';
+
+export const DEFAULT_CONFIG = Object.freeze({
+  rendering: RENDERING_BACKENDS.WEBGL,
+  exec: EXECUTION_MODES.SYNC,
+});
+
+export const WASM_FILE_EXTENSION = '.wasm';
+
+export const MODULE_JS_FILE_EXTENSION = '.mjs';
+
+export const MIME_TYPES = Object.freeze({
+  WASM: 'application/wasm',
+  JAVASCRIPT: 'application/javascript',
+});

--- a/src/core/future.js
+++ b/src/core/future.js
@@ -1,0 +1,12 @@
+/**
+ * Create a future that returns
+ * @returns { promise, resolve, reject }
+ */
+export function createFuture() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}

--- a/src/core/gzipBundle.js
+++ b/src/core/gzipBundle.js
@@ -1,0 +1,64 @@
+import untar from "js-untar";
+import { stripLeadingDotSlash } from "./stringOps.js";
+import { createFuture } from "./future.js";
+import { MODULE_JS_FILE_EXTENSION, WASM_FILE_EXTENSION } from "./constants.js";
+
+/**
+ * Check if provided URL points to a gzip bundle
+ * @param {string} url 
+ * @returns {boolean}
+ */
+export function isGzipBundle(url) {
+  return typeof url === "string" && url.endsWith(".gz");
+}
+
+/**
+ * Fetch gzip bundle from provided URL
+ * @param {string} url 
+ * @returns {Promise<ArrayBuffer>} The decompressed tar archive contents from the gzip bundle.
+ */
+export function fetchGzipBundle(url) {
+  const { promise, resolve, reject } = createFuture();
+  fetch(url).then((response) => {
+    if (response.ok) {
+      const decompressedStream = response.body.pipeThrough(new DecompressionStream('gzip'));
+      const decompressionResponse = new Response(decompressedStream);
+      decompressionResponse
+        .blob()
+        .then((blob) => blob.arrayBuffer())
+        .then(resolve)
+        .catch(reject);
+    }
+    else {
+      reject(new Error(`Could not fetch gzip bundle from ${url} - response status: ${response.status}`));
+    }
+  }).catch(reject);
+  return promise;
+}
+
+/**
+ * Extract the JavaScript and WebAssembly files from gzip bundle.
+ * @param {ArrayBuffer} contents 
+ * @param {object} config 
+ * @param {string} wasmBaseName 
+ * @returns {Promise<{js: {name: string, buffer: ArrayBufferLike}, wasm: {name: string, buffer: ArrayBufferLike}}>}
+ */
+export function extractFilesFromGzipBundle(contents, config, wasmBaseName) {
+  const { promise, resolve, reject } = createFuture();
+  untar(contents)
+    .then((files) => {
+      const execModeSuffix = config?.exec === "async" ? "Async" : "";
+      const jsFileMatch = `${wasmBaseName}WebAssembly${execModeSuffix}${MODULE_JS_FILE_EXTENSION}`;
+      const wasmFileMatch = `${wasmBaseName}WebAssembly${execModeSuffix}${WASM_FILE_EXTENSION}`;
+      const jsFile = files.find((file) => stripLeadingDotSlash(file.name) === jsFileMatch);
+      const wasmFile = files.find((file) => stripLeadingDotSlash(file.name) === wasmFileMatch);
+      if (jsFile === undefined || wasmFile === undefined) {
+        reject(new Error(`Could not find expected files ${jsFileMatch} and ${wasmFileMatch} in the gzip bundle`));
+      }
+      else {
+        resolve({ js: jsFile, wasm: wasmFile });
+      }
+    })
+    .catch(reject);
+  return promise;
+}

--- a/src/core/javaScriptCxxTranslators.js
+++ b/src/core/javaScriptCxxTranslators.js
@@ -1,0 +1,47 @@
+/**
+ * Converts a C++ style name (PascalCase) to a JavaScript style name (camelCase).
+ * @param {string} cxxName 
+ * @returns {string}
+ */
+export function toJsName(cxxName) {
+  const jsName = `${cxxName.charAt(0).toLowerCase()}${cxxName.slice(1)}`;
+  // console.log("c2j", cxxName, "=>", jsName);
+  return jsName;
+}
+
+/**
+ * Converts a JavaScript style name (camelCase) to a C++ style name (PascalCase).
+ * @param {string} jsName 
+ * @returns {string}
+ */
+export function toCxxName(jsName) {
+  const cxxName = `${jsName.charAt(0).toUpperCase()}${jsName.slice(1)}`;
+  // console.log("j2c", jsName, "=>", cxxName);
+  return cxxName;
+}
+
+/**
+ * Convert JS-style keyword arguments to C++-style keyword arguments.
+ * @param {object} kwArgs 
+ * @returns {object}
+ */
+export function toCxxKeys(kwArgs) {
+  const wrapped = {};
+  Object.entries(kwArgs).forEach(([k, v]) => {
+    wrapped[toCxxName(k)] = v;
+  });
+  return wrapped;
+}
+
+/**
+ * Convert C++-style keyword arguments to JS-style keyword arguments.
+ * @param {object} kwArgs 
+ * @returns {object}
+ */
+export function toJsKeys(kwArgs) {
+  const wrapped = {};
+  Object.entries(kwArgs).forEach(([k, v]) => {
+    wrapped[toJsName(k)] = v;
+  });
+  return wrapped;
+}

--- a/src/core/proxy.js
+++ b/src/core/proxy.js
@@ -1,0 +1,212 @@
+import { toCxxName, toCxxKeys, toJsName, toJsKeys } from "./javaScriptCxxTranslators";
+
+
+export function createPropGetter(wasm, wrapMethods, vtkId) {
+  if (!wasm.get) {
+    return {};
+  }
+
+  const fullState = wasm.get(vtkId);
+  const getPropHandler = {};
+  Object.keys(fullState).forEach((propName) => {
+    // console.log("Prop key:", propName);
+    getPropHandler[toJsName(propName)] = () =>
+      wrapMethods.decorateResult(wasm.get(vtkId)[propName]);
+  });
+  return getPropHandler;
+}
+
+function createPropSetter(wasm, wrapMethods, vtkId) {
+  if (!wasm.get) {
+    return {};
+  }
+  const fullState = wasm.get(vtkId);
+  const setPropHandler = {};
+  Object.keys(fullState).forEach((propName) => {
+    setPropHandler[toJsName(propName)] = (value) =>
+      wasm.set(vtkId, wrapMethods.decorateKwargs({ [propName]: value }));
+  });
+  return setPropHandler;
+}
+
+export function createVtkObjectProxy(
+  wasm,
+  vtkProxyCache,
+  idToRef,
+  wrapMethods,
+  vtkId,
+) {
+  // Reuse vtkProxy if already available
+  if (idToRef.has(vtkId) && idToRef.get(vtkId).deref()) {
+    return idToRef.get(vtkId).deref();
+  }
+
+  // Create methods
+  const observerTags = [];
+  function set(props) {
+    return wasm.set(vtkId, wrapMethods.decorateKwargs(toCxxKeys(props)));
+  }
+  function observe(event, callback) {
+    const tag = wasm.observe(vtkId, event, callback);
+    observerTags.push(tag);
+    return tag;
+  }
+  function unObserve(tag) {
+    const tagIdx = observerTags.indexOf(tag);
+    if (tagIdx !== -1) {
+      observerTags.splice(tagIdx, 1);
+    }
+    return wasm.unObserve(vtkId, tag);
+  }
+  function unObserveAll() {
+    while (observerTags.length) {
+      unObserve(observerTags.pop());
+    }
+  }
+  const propGetters = createPropGetter(wasm, wrapMethods, vtkId);
+  const propSetters = createPropSetter(wasm, wrapMethods, vtkId);
+
+  // Extract properties and unCapitalize them & add setter
+
+  // Create proxy for given vtk object
+  const target = {
+    id: vtkId,
+    obj: { Id: vtkId },
+    set,
+    observe,
+    unObserve,
+    unObserveAll,
+  };
+  const vtkProxy = new Proxy(target, {
+    get(target, prop, resolver) {
+      if (prop === "then") {
+        return resolver;
+      }
+      if (prop === "state") {
+        if (!wasm.get) {
+          // To support old remote API
+          wasm.updateStateFromObject(vtkId);
+          return toJsKeys(wasm.getState(vtkId));
+        }
+        return toJsKeys(wasm.get(vtkId));
+      }
+      if (prop === "delete") {
+        const result = wasm.destroy(vtkId);
+        if (result) {
+          const removedProxy = idToRef.delete(vtkId);
+          vtkProxyCache.delete(removedProxy);
+        }
+        return result;
+      }
+      if (propGetters[prop]) {
+        return propGetters[prop]();
+      }
+      if (!target[prop]) {
+        // console.log("register method", prop, toCxxName(prop));
+        target[prop] = async (...args) =>
+          wrapMethods.decorateResult(
+            await wasm.invoke(
+              vtkId,
+              toCxxName(prop),
+              wrapMethods.decorateArgs(args),
+            ),
+          );
+      }
+      return target[prop];
+    },
+    set(target, property, value) {
+      if (propSetters[property]) {
+        propSetters[property](value);
+      }
+      return value;
+    },
+  });
+
+  // Update maps
+  idToRef.set(vtkId, new WeakRef(vtkProxy));
+  vtkProxyCache.set(vtkProxy, true);
+
+  return vtkProxy;
+}
+
+export function createInstantiatorProxy(wasm, vtkProxyCache, idToRef) {
+  function isVtkObject(obj) {
+    return vtkProxyCache.has(obj);
+  }
+
+  function decorateKwargs(kwargs) {
+    const wrapped = {};
+    Object.entries(kwargs).forEach(([k, v]) => {
+      if (vtkProxyCache.has(v)) {
+        wrapped[k] = v.obj;
+      } else {
+        wrapped[k] = v;
+      }
+    });
+    return wrapped;
+  }
+
+  function decorateArgs(args) {
+    return args.map((v) => (vtkProxyCache.has(v) ? v.obj : v));
+  }
+
+  const internalMethods = { isVtkObject, decorateKwargs, decorateArgs };
+
+  function decorateResult(result) {
+    if (result == null) {
+      return result;
+    }
+    if (result?.Id) {
+      return createVtkObjectProxy(
+        wasm,
+        vtkProxyCache,
+        idToRef,
+        internalMethods,
+        result.Id,
+      );
+    }
+    return result;
+  }
+  internalMethods.decorateResult = decorateResult;
+
+  function getVtkObject(obj_or_id) {
+    return createVtkObjectProxy(
+      wasm,
+      vtkProxyCache,
+      idToRef,
+      internalMethods,
+      obj_or_id.Id || obj_or_id,
+    );
+  }
+
+  function create(name, args) {
+    const vtkId = wasm.create(name);
+    if (args) {
+      wasm.set(vtkId, decorateKwargs(toCxxKeys(args)));
+    }
+    return createVtkObjectProxy(
+      wasm,
+      vtkProxyCache,
+      idToRef,
+      internalMethods,
+      vtkId,
+    );
+  }
+
+  return new Proxy(
+    { getVtkObject },
+    {
+      get(target, prop, resolver) {
+        if (prop === "then") {
+          return resolver;
+        }
+        if (!target[prop]) {
+          // console.log("register create method for", prop);
+          target[prop] = (args) => create(prop, args);
+        }
+        return target[prop];
+      },
+    },
+  );
+}
+

--- a/src/core/scriptLoader.js
+++ b/src/core/scriptLoader.js
@@ -1,0 +1,114 @@
+import { createFuture } from "./future";
+import { isHTMLDocument } from "./stringOps";
+import { MODULE_JS_FILE_EXTENSION } from "./constants";
+
+const LOADED_URLS = [];
+const PROMISES = {};
+
+/**
+ * Wait for existing wasm script to be loaded.
+ * This is useful when the script tag with a path to the wasm module already
+ * exists in the HTML document.
+ * 
+ * @param {string} wasmBaseName 
+ * @returns {Promise<void>}
+ */
+export function loadWebAssemblyModuleFromExistingScript(wasmBaseName) {
+  if (window.createVTKWASM) {
+    return Promise.resolve();
+  }
+
+  let scriptPromise = null;
+  const scriptName = `${wasmBaseName}WebAssembly`;
+  const scripts = document.querySelectorAll("script");
+  for (const script of scripts) {
+    if (script.src.includes(scriptName)) {
+      const { promise, resolve, reject } = createFuture();
+      script.onload = resolve;
+      script.onerror = () => {
+        reject(new Error(`Failed to load script: ${script.src}`));
+      };
+      scriptPromise = promise;
+      break;
+    }
+  }
+  if (scriptPromise) {
+    return scriptPromise;
+  } else {
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Add script tag with provided URL with type="module"
+ *
+ * @param {string} url a URL to the wasm module JavaScript file
+ * @return {Promise<void>} to know when the script is ready
+ */
+export function loadWebAssemblyModuleFromScript(url) {
+  if (PROMISES[url]) {
+    return PROMISES[url];
+  }
+
+  PROMISES[url] = new Promise(function (resolve, reject) {
+    if (LOADED_URLS.indexOf(url) === -1) {
+      LOADED_URLS.push(url);
+      const newScriptTag = document.createElement("script");
+      newScriptTag.type = "module";
+      newScriptTag.src = url;
+      newScriptTag.onload = resolve;
+      newScriptTag.onerror = () => {
+        reject(new Error(`Failed to load script: ${url}`));
+      };
+      document.body.appendChild(newScriptTag);
+    } else {
+      // Already loaded.
+      resolve(false);
+    }
+  });
+
+  return PROMISES[url];
+}
+
+/**
+ * Get the URL of the WebAssembly module JavaScript file. This is the glue
+ * code that loads the WebAssembly binary. It tries to fetch the file to
+ * ensure it exists. If the fetch fails, an error is thrown.
+ * 
+ * Set legacy to true for legacy-style wasm modules `vtkWasmSceneManager.mjs`, not `vtkWebAssembly[Async].mjs`.
+ * 
+ * This is a fallback when not using GZIP bundles.
+ * 
+ * @param {string} wasmBaseURL URL where the wasm module JavaScript file is located
+ * @param {string} wasmBaseName Base name of the wasm module JavaScript file 
+ * @param {object} config Configuration object
+ * @returns {Promise<string>} URL of the wasm module JavaScript file
+ */
+export async function createScriptURL(wasmBaseURL, wasmBaseName, config, legacy = false) {
+  let execModeSuffix = "";
+  if (!legacy) {
+    execModeSuffix = config?.exec === "async" ? "Async" : "";
+  }
+  const filename = legacy
+    ? `vtkWasmSceneManager${MODULE_JS_FILE_EXTENSION}`
+    : `${wasmBaseName}WebAssembly${execModeSuffix}${MODULE_JS_FILE_EXTENSION}`;
+  const url = `${wasmBaseURL}/${filename}`;
+  const { promise, resolve, reject } = createFuture();
+  fetch(url)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Could not fetch ${filename} from ${url}`);
+      }
+      return response.text();
+    })
+    .then((content) => {
+      // In docker we serve the index.html when the file doesn't exist, so test that this is not html.
+      if (isHTMLDocument(content)) {
+        throw new Error(`Could not fetch ${filename} from ${url}`);
+      }
+      // Not html content
+      resolve(url);
+    })
+    .catch(reject);
+  return promise;
+}

--- a/src/core/sessionFactory.js
+++ b/src/core/sessionFactory.js
@@ -1,0 +1,44 @@
+import { createEmscriptenConfig, isSameConfig } from "./configManager.js";
+
+/**
+ * Create a vtkRemoteSession, reusing existing wasmInstance if possible
+ * @param {object} config 
+ * @param {object} currentConfig 
+ * @param {*} wasmInstance 
+ * @returns {vtkRemoteSession}
+ */
+export async function createRemoteSession(config, currentConfig, wasmInstance) {
+  if (wasmInstance) {
+    // New API
+    if (wasmInstance?.isAsync && wasmInstance.isAsync()) {
+      if (!config || isSameConfig(currentConfig, config)) {
+        // Reuse the same runtime
+        console.debug("Reusing existing async WASM runtime for remote session");
+        return new wasmInstance.vtkRemoteSession();
+      } else {
+        console.debug("Creating new async WASM runtime for remote session");
+        const newWASMRuntime = await window.createVTKWASM(
+          createEmscriptenConfig(config || currentConfig),
+        );
+        return new newWASMRuntime.vtkRemoteSession();
+      }
+    } else {
+      if (!config || isSameConfig(currentConfig, config)) {
+        // Reuse the same runtime
+        console.debug("Reusing existing sync WASM runtime for remote session");
+        return new wasmInstance.vtkRemoteSession();
+      } else {
+        console.debug("Creating new sync WASM runtime for remote session");
+        const newWASMRuntime = await window.createVTKWASM(
+          createEmscriptenConfig(config || currentConfig),
+        );
+        return new newWASMRuntime.vtkRemoteSession();
+      }
+    }
+  }
+
+  // Old API
+  const remoteSession = await window.createVTKWasmSceneManager();
+  remoteSession.initialize();
+  return remoteSession;
+}

--- a/src/core/stateDecorators.js
+++ b/src/core/stateDecorators.js
@@ -1,0 +1,23 @@
+/**
+ * Convert state to object
+ * @param {string|object} state 
+ * @returns {object}
+ */
+export function convertToObj(state) {
+  if (state?.Id) {
+    return state;
+  }
+  return JSON.parse(state);
+}
+
+/**
+ * Convert state to string
+ * @param {string|object} state 
+ * @returns {string}
+ */
+export function convertToStr(state) {
+  if (state?.Id) {
+    return JSON.stringify(state);
+  }
+  return state;
+}

--- a/src/core/stringOps.js
+++ b/src/core/stringOps.js
@@ -1,0 +1,33 @@
+/**
+ * Strip leading './' from path.
+ *
+ * If {@code path} is not a string, a warning is logged and an empty string is returned.
+ *
+ * @param {*} path
+ * @returns {string} The path without a leading "./", or an empty string if {@code path} is not a string.
+ */
+export function stripLeadingDotSlash(path) {
+  if (typeof path !== 'string') {
+    console.warn('stripLeadingDotSlash: provided path is not a string');
+    return '';
+  }
+  return path.replace(/^\.\//, '');
+}
+
+/**
+ * Check if text is an HTML document
+ * @param {string} text 
+ * @returns {boolean}
+ */
+export function isHTMLDocument(text) {
+  if (typeof text !== 'string') {
+    return false;
+  }
+
+  const trimmed = text.trimStart();
+
+  // Note: this is a lightweight heuristic and does not attempt to validate a
+  // full HTML document; it only looks for common document‑level markers.
+  return /^<\s*!DOCTYPE\s+html\b/i.test(trimmed) ||
+         /^<\s*html[\s>]/i.test(trimmed);
+}

--- a/src/remote.js
+++ b/src/remote.js
@@ -1,7 +1,7 @@
 import "./style.css";
 
 import { VtkWASMLoader } from "./wasmLoader";
-import { createVtkObjectProxy } from "./standalone";
+import { createVtkObjectProxy } from "./core/proxy";
 
 // url => loader instance
 const WASM_LOADERS = {};

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -1,241 +1,6 @@
-import { VtkWASMLoader, createFuture } from "./wasmLoader";
-
-function toJsName(cxxName) {
-  const jsName = `${cxxName.charAt(0).toLowerCase()}${cxxName.slice(1)}`;
-  // console.log("c2j", cxxName, "=>", jsName);
-  return jsName;
-}
-
-function toCxxName(jsName) {
-  const cxxName = `${jsName.charAt(0).toUpperCase()}${jsName.slice(1)}`;
-  // console.log("j2c", jsName, "=>", cxxName);
-  return cxxName;
-}
-
-function toCxxKeys(kwArgs) {
-  const wrapped = {};
-  Object.entries(kwArgs).forEach(([k, v]) => {
-    wrapped[toCxxName(k)] = v;
-  });
-  return wrapped;
-}
-
-function toJsKeys(kwArgs) {
-  const wrapped = {};
-  Object.entries(kwArgs).forEach(([k, v]) => {
-    wrapped[toJsName(k)] = v;
-  });
-  return wrapped;
-}
-
-function createPropGetter(wasm, wrapMethods, vtkId) {
-  if (!wasm.get) {
-    return {};
-  }
-
-  const fullState = wasm.get(vtkId);
-  const getPropHandler = {};
-  Object.keys(fullState).forEach((propName) => {
-    // console.log("Prop key:", propName);
-    getPropHandler[toJsName(propName)] = () =>
-      wrapMethods.decorateResult(wasm.get(vtkId)[propName]);
-  });
-  return getPropHandler;
-}
-
-function createPropSetter(wasm, wrapMethods, vtkId) {
-  if (!wasm.get) {
-    return {};
-  }
-  const fullState = wasm.get(vtkId);
-  const setPropHandler = {};
-  Object.keys(fullState).forEach((propName) => {
-    setPropHandler[toJsName(propName)] = (value) =>
-      wasm.set(vtkId, wrapMethods.decorateKwargs({ [propName]: value }));
-  });
-  return setPropHandler;
-}
-
-export function createVtkObjectProxy(
-  wasm,
-  vtkProxyCache,
-  idToRef,
-  wrapMethods,
-  vtkId,
-) {
-  // Reuse vtkProxy if already available
-  if (idToRef.has(vtkId) && idToRef.get(vtkId).deref()) {
-    return idToRef.get(vtkId).deref();
-  }
-
-  // Create methods
-  const observerTags = [];
-  function set(props) {
-    return wasm.set(vtkId, wrapMethods.decorateKwargs(toCxxKeys(props)));
-  }
-  function observe(event, callback) {
-    const tag = wasm.observe(vtkId, event, callback);
-    observerTags.push(tag);
-    return tag;
-  }
-  function unObserve(tag) {
-    const tagIdx = observerTags.indexOf(tag);
-    if (tagIdx !== -1) {
-      observerTags.splice(tagIdx, 1);
-    }
-    return wasm.unObserve(vtkId, tag);
-  }
-  function unObserveAll() {
-    while (observerTags.length) {
-      unObserve(observerTags.pop());
-    }
-  }
-  const propGetters = createPropGetter(wasm, wrapMethods, vtkId);
-  const propSetters = createPropSetter(wasm, wrapMethods, vtkId);
-
-  // Extract properties and unCapitalize them & add setter
-
-  // Create proxy for given vtk object
-  const target = {
-    id: vtkId,
-    obj: { Id: vtkId },
-    set,
-    observe,
-    unObserve,
-    unObserveAll,
-  };
-  const vtkProxy = new Proxy(target, {
-    get(target, prop, resolver) {
-      if (prop === "then") {
-        return resolver;
-      }
-      if (prop === "state") {
-        if (!wasm.get) {
-          // To support old remote API
-          wasm.updateStateFromObject(vtkId);
-          return toJsKeys(wasm.getState(vtkId));
-        }
-        return toJsKeys(wasm.get(vtkId));
-      }
-      if (prop === "delete") {
-        const result = wasm.destroy(vtkId);
-        if (result) {
-          const removedProxy = idToRef.delete(vtkId);
-          vtkProxyCache.delete(removedProxy);
-        }
-        return result;
-      }
-      if (propGetters[prop]) {
-        return propGetters[prop]();
-      }
-      if (!target[prop]) {
-        // console.log("register method", prop, toCxxName(prop));
-        target[prop] = async (...args) =>
-          wrapMethods.decorateResult(
-            await wasm.invoke(
-              vtkId,
-              toCxxName(prop),
-              wrapMethods.decorateArgs(args),
-            ),
-          );
-      }
-      return target[prop];
-    },
-    set(target, property, value) {
-      if (propSetters[property]) {
-        propSetters[property](value);
-      }
-      return value;
-    },
-  });
-
-  // Update maps
-  idToRef.set(vtkId, new WeakRef(vtkProxy));
-  vtkProxyCache.set(vtkProxy, true);
-
-  return vtkProxy;
-}
-
-function createInstanciatorProxy(wasm, vtkProxyCache, idToRef) {
-  function isVtkObject(obj) {
-    return vtkProxyCache.has(obj);
-  }
-
-  function decorateKwargs(kwargs) {
-    const wrapped = {};
-    Object.entries(kwargs).forEach(([k, v]) => {
-      if (vtkProxyCache.has(v)) {
-        wrapped[k] = v.obj;
-      } else {
-        wrapped[k] = v;
-      }
-    });
-    return wrapped;
-  }
-
-  function decorateArgs(args) {
-    return args.map((v) => (vtkProxyCache.has(v) ? v.obj : v));
-  }
-
-  const internalMethods = { isVtkObject, decorateKwargs, decorateArgs };
-
-  function decorateResult(result) {
-    if (result == null) {
-      return result;
-    }
-    if (result?.Id) {
-      return createVtkObjectProxy(
-        wasm,
-        vtkProxyCache,
-        idToRef,
-        internalMethods,
-        result.Id,
-      );
-    }
-    return result;
-  }
-  internalMethods.decorateResult = decorateResult;
-
-  function getVtkObject(obj_or_id) {
-    return createVtkObjectProxy(
-      wasm,
-      vtkProxyCache,
-      idToRef,
-      internalMethods,
-      obj_or_id.Id || obj_or_id,
-    );
-  }
-
-  function create(name, args) {
-    const vtkId = wasm.create(name);
-    if (args) {
-      wasm.set(vtkId, decorateKwargs(toCxxKeys(args)));
-    }
-    return createVtkObjectProxy(
-      wasm,
-      vtkProxyCache,
-      idToRef,
-      internalMethods,
-      vtkId,
-    );
-  }
-
-  return new Proxy(
-    { getVtkObject },
-    {
-      get(target, prop, resolver) {
-        if (prop === "then") {
-          return resolver;
-        }
-        if (!target[prop]) {
-          // console.log("register create method for", prop);
-          target[prop] = (args) => create(prop, args);
-        }
-        return target[prop];
-      },
-    },
-  );
-}
+import { VtkWASMLoader } from "./wasmLoader";
+import { createFuture } from "./core/future";
+import { createInstantiatorProxy } from "./core/proxy";
 
 /**
  * Create a VTK namespace for handling vtk object creation.
@@ -255,7 +20,7 @@ export async function createNamespace(url, config = {}, wasmBaseName = "vtk") {
   await loader.load(url || "loaded-module", config, wasmBaseName);
   const wasm = loader.createStandaloneSession();
 
-  return createInstanciatorProxy(wasm, vtkProxyCache, idToRef);
+  return createInstantiatorProxy(wasm, vtkProxyCache, idToRef);
 }
 
 /**
@@ -274,10 +39,12 @@ if (script) {
   const url = script.dataset.url || ".";
   const config = JSON.parse(script.dataset.config || "{}");
   window.vtkReady = promise;
-  createNamespace(url, config).then((vtk) => {
-    window.vtk = vtk;
-    resolve(vtk);
-  });
+  createNamespace(url, config)
+    .then((vtk) => {
+      window.vtk = vtk;
+      resolve(vtk);
+    })
+    .catch(reject);
 } else {
-  reject('No script with id="vtk-wasm"');
+  reject("Automatic VTK namespace initialization is disabled because no <script id=\"vtk-wasm\"> tag was found. See https://kitware.github.io/vtk-wasm/guide/js/plain.html#defer-wasm-loading-with-annotation'");
 }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1,6 +1,6 @@
 import JSZip from "jszip";
 import { RemoteSession } from "./remote";
-import { createFuture } from "./wasmLoader";
+import { createFuture } from "./core/future";
 
 export class ExportViewer {
   constructor(containerSelector, remoting) {

--- a/src/wasmLoader.js
+++ b/src/wasmLoader.js
@@ -1,66 +1,11 @@
-import untar from "js-untar";
-
-const LOADED_URLS = [];
-const PROMISES = {};
-
-/**
- * Create a future that returns
- * @returns { promise, resolve, reject }
- */
-export function createFuture() {
-  let resolve, reject;
-  const promise = new Promise((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
-
-function convertToObj(state) {
-  if (state?.Id) {
-    return state;
-  }
-  return JSON.parse(state);
-}
-
-function convertToStr(state) {
-  if (state?.Id) {
-    return JSON.stringify(state);
-  }
-  return state;
-}
-
-function isSameConfig(a, b) {
-  return a.rendering === b.rendering && a.exec === b.exec;
-}
-
-/**
- * Add script tag with provided URL with type="module"
- *
- * @param {string} url
- * @return {Promise<void>} to know when the script is ready
- */
-export function loadScriptAsModule(url) {
-  if (PROMISES[url]) {
-    return PROMISES[url];
-  }
-
-  PROMISES[url] = new Promise(function (resolve, reject) {
-    if (LOADED_URLS.indexOf(url) === -1) {
-      LOADED_URLS.push(url);
-      var newScriptTag = document.createElement("script");
-      newScriptTag.type = "module";
-      newScriptTag.src = url;
-      newScriptTag.onload = resolve;
-      newScriptTag.onerror = reject;
-      document.body.appendChild(newScriptTag);
-    } else {
-      resolve(false);
-    }
-  });
-
-  return PROMISES[url];
-}
+import { extractFilesFromGzipBundle, fetchGzipBundle, isGzipBundle } from "./core/gzipBundle";
+import { createEmscriptenConfig, normalizeConfig, validateConfig } from "./core/configManager";
+import { DEFAULT_CONFIG, MIME_TYPES } from "./core/constants";
+import { createScriptURL, loadWebAssemblyModuleFromExistingScript, loadWebAssemblyModuleFromScript } from "./core/scriptLoader";
+import { createRemoteSession } from "./core/sessionFactory";
+import { createFuture } from "./core/future";
+import { createBlobURL, disposeBlobURL } from "./core/blobURL";
+import { convertToObj, convertToStr } from "./core/stateDecorators";
 
 /**
  * VtkWASMLoader type definition
@@ -69,14 +14,16 @@ export function loadScriptAsModule(url) {
  * @property {Boolean} loaded
  */
 export class VtkWASMLoader {
-  #wasm;
-  #wasmFile;
+  #config = null;
+  #loaded = false;
+  #pendingLoad = null;
+  #wasmInstance = null;
+
   constructor() {
-    this.loaded = false;
-    this.loadingPending = null;
-    this.config = {};
-    this.#wasm = { url: null, instance: null };
-    this.#wasmFile = null;
+    this.#config = {};
+    this.#loaded = false;
+    this.#pendingLoad = null;
+    this.#wasmInstance = null;
   }
 
   /**
@@ -92,212 +39,148 @@ export class VtkWASMLoader {
    *     exec: "sync", // or "async"
    *   }
    *
-   * @param {str} wasmBaseURL
+   * @param {string} wasmBaseURL
    * @param {object} config - for WASM runtime creation.
-   * @param {str} wasmBaseName - (default is "vtk") base name of the wasm bundle to load. e.g., "vtk" or "addon" will
+   * @param {string} wasmBaseName - (default is "vtk") base name of the wasm bundle to load. e.g., "vtk" or "addon" will
    *                             look for vtkWebAssembly.mjs or addonWebAssembly.mjs in the wasmBaseURL.
    */
   async load(
     wasmBaseURL,
-    config = { rendering: "webgl", exec: "sync" },
+    config = DEFAULT_CONFIG,
     wasmBaseName = "vtk",
   ) {
-    this.config = config;
-    if (this.loaded) {
+    if (this.#loaded) {
       return;
     }
+    validateConfig(config);
+    this.#config = normalizeConfig(config);
 
-    if (!this.loadingPending) {
-      const { promise, resolve } = createFuture();
-      this.loadingPending = promise;
+    if (!this.#pendingLoad) {
+      const { promise, resolve, reject } = createFuture();
+      this.#pendingLoad = promise;
 
-      // WebGPU only works in async mode
-      if (this.config?.rendering === "webgpu") {
-        this.config.exec = "async";
+      // wait for wasm script to load if any (first priority)
+      if (!window.createVTKWASM) {
+        await loadWebAssemblyModuleFromExistingScript(wasmBaseName);
       }
 
-      // wait for wasm script to load if any
+      let wasmFile = null;
       if (!window.createVTKWASM) {
-        let scriptLoaded = null;
-        document.querySelectorAll("script").forEach((script) => {
-          if (script.src.includes(`${wasmBaseName}WebAssembly`)) {
-            const { promise, resolve } = createFuture();
-            script.onload = resolve;
-            scriptLoaded = promise;
+        if (isGzipBundle(wasmBaseURL)) {
+          let gzipArrayBuffer;
+          let javaScriptBlobURL = null;
+          try {
+            gzipArrayBuffer = await fetchGzipBundle(wasmBaseURL);
+          } catch (e) {
+            reject(e);
+            this.#pendingLoad = null;
+            return;
           }
-        });
-        if (scriptLoaded) {
-          await scriptLoaded;
-        }
-      }
-
-      if (!window.createVTKWASM) {
-        // Check which wasm bundle we have
-        let url = null;
-        let jsModuleURL = null;
-
-        // Try newest version first
-        let newModuleResponse = null;
-        if (wasmBaseURL.startsWith("http") && wasmBaseURL.endsWith(".gz")) {
-          // Absolute URL pointing to a GZIP file.
-          newModuleResponse = await fetch(wasmBaseURL);
-          const ds = new DecompressionStream("gzip");
-          const decompressedStream = newModuleResponse.body.pipeThrough(ds);
-          const blob = await new Response(decompressedStream).blob();
-          const arrayBuffer = await blob.arrayBuffer();
-          const files = await untar(arrayBuffer);
-          files.forEach((file) => {
-            file.name = file.name.replace("./", "");
-            if (file.name === `${wasmBaseName}WebAssembly${this.config?.exec === "async" ? "Async" : ""}.mjs`) {
-              jsModuleURL = URL.createObjectURL(new File([file.buffer], file.name, { type: "text/javascript" }));
-            } else if (file.name === `${wasmBaseName}WebAssembly${this.config?.exec === "async" ? "Async" : ""}.wasm`) {
-              this.#wasmFile = file;
+          try {
+            const result = await extractFilesFromGzipBundle(
+              gzipArrayBuffer,
+              this.#config,
+              wasmBaseName,
+            );
+            wasmFile = result.wasm;
+            javaScriptBlobURL = createBlobURL(result.js.buffer, MIME_TYPES.JAVASCRIPT);
+            await loadWebAssemblyModuleFromScript(javaScriptBlobURL);
+          } catch (e) {
+            reject(e);
+            this.#pendingLoad = null;
+            return;
+          }
+          finally {
+            if (javaScriptBlobURL !== null) {
+              disposeBlobURL(javaScriptBlobURL);
             }
-          });
+          }
         } else {
-          url = `${wasmBaseURL}/${wasmBaseName}WebAssembly${this.config?.exec === "async" ? "Async" : ""}.mjs`;
-          newModuleResponse = await fetch(url);
-          if (newModuleResponse.ok) {
-            // In docker we serve the index.html when file don't exist
-            const content = await newModuleResponse.text();
-            if (content[0] !== "<") {
-              // Not html content
-              jsModuleURL = url;
+          try {
+            const scriptURL = await createScriptURL(wasmBaseURL, wasmBaseName, this.#config);
+            await loadWebAssemblyModuleFromScript(scriptURL);
+            // if window.createVTKWASM is still not defined, try legacy loader
+            if (!window.createVTKWASM) {
+              const legacyScriptURL = await createScriptURL(wasmBaseURL, null, null, true);
+              await loadWebAssemblyModuleFromScript(legacyScriptURL);
             }
+          } catch (e) {
+            reject(e);
+            this.#pendingLoad = null;
+            return;
           }
-        }
-
-        // Try older version
-        if (!jsModuleURL) {
-          url = `${wasmBaseURL}/vtkWasmSceneManager.mjs`;
-          const oldModuleResponse = await fetch(url);
-          if (oldModuleResponse.ok) {
-            // In docker we serve the index.html when file don't exist
-            const content = await oldModuleResponse.text();
-            if (content[0] !== "<") {
-              // Not html content
-              jsModuleURL = url;
-            }
-          }
-        }
-
-        // Not sure what to do
-        if (!jsModuleURL) {
-          throw new Error(`Could not fetch wasm bundle from ${wasmBaseURL}`);
-        }
-
-        // Load JS
-        console.log("WASM use", jsModuleURL);
-        await loadScriptAsModule(jsModuleURL);
-        // Cleanup object URL corresponding to the JavaScript module.
-        if (jsModuleURL.startsWith("blob:")) {
-          URL.revokeObjectURL(jsModuleURL);
         }
       }
 
       // Load WASM
       if (window.createVTKWASM) {
-        this.#wasm.instance = await window.createVTKWASM(this.#generateWasmConfig(this.config));
+        try {
+          this.#wasmInstance = await window.createVTKWASM(createEmscriptenConfig(this.#config, wasmFile));
+        } catch (e) {
+          reject(e);
+          this.#pendingLoad = null;
+          return;
+        }
+        this.#loaded = true;
+        resolve();
+        this.#pendingLoad = null;
+      } else {
+        const errorMessage = [
+          "Could not load WebAssembly module: window.createVTKWASM is not available after loading scripts.",
+          "Possible causes include:",
+          `  - Incorrect or unreachable 'wasmBaseURL' ("${wasmBaseURL}")`,
+          `  - Wrong 'wasmBaseName' ("${wasmBaseName}") or missing/misnamed .mjs/.wasm files in the bundle`,
+          "  - Network or script loading failures (e.g., 404/500 responses)",
+          "  - Content Security Policy (CSP) blocking script execution",
+          "",
+          "Next steps:",
+          "  - Verify that the expected .mjs and .wasm files are present and accessible under 'wasmBaseURL'",
+          "  - Check the browser's Network/Console tabs for failed script requests or CSP errors.",
+        ].join("\n");
+        reject(new Error(errorMessage));
+        this.#pendingLoad = null;
       }
-
-      // Capture objects
-      this.loaded = true;
-      resolve();
     } else {
-      await this.loadingPending;
+      await this.#pendingLoad;
     }
   }
 
   /**
    * Create a new remote session and return it regardless of WASM version.
    *
-   * @returns
+   * @returns {Promise<vtkRemoteSession>}
    */
   async createRemoteSession(config) {
-    if (this.#wasm.instance) {
-      // New API
-      if (this.#wasm.instance?.isAsync && this.#wasm.instance.isAsync()) {
-        if (!config || isSameConfig(this.config, config)) {
-          // Reuse the same runtime
-          console.log("(Main runtime in async)");
-          return new this.#wasm.instance.vtkRemoteSession();
-        } else {
-          console.log("(New in async)");
-          const newWASMRuntime = await window.createVTKWASM(
-            this.#generateWasmConfig(config || this.config),
-          );
-          return new newWASMRuntime.vtkRemoteSession();
-        }
-      } else {
-        console.log("(New in sync)");
-        if (!config || isSameConfig(this.config, config)) {
-          // Reuse the same runtime
-          return new this.#wasm.instance.vtkRemoteSession();
-        }
-        else {
-          const newWASMRuntime = await window.createVTKWASM(
-            this.#generateWasmConfig(config || this.config),
-          );
-          return new newWASMRuntime.vtkRemoteSession();
-        }
-      }
+    if (!this.#loaded) {
+      throw new Error("WASM module is not loaded yet. Call load() first.");
     }
-
-    // Old API
-    const remoteSession = await window.createVTKWasmSceneManager();
-    remoteSession.initialize();
+    const remoteSession = await createRemoteSession(config, this.#config, this.#wasmInstance);
     return remoteSession;
   }
 
   /**
    * Create a new standalone session. Only works with new WASM bundle.
    *
-   * @returns
+   * @returns {vtkStandaloneSession}
    */
   createStandaloneSession() {
-    if (!this.#wasm.instance) {
-      throw new Error("Current WASM version does not support standalone mode");
+    if (!this.#loaded) {
+      throw new Error("WASM module is not loaded yet. Call load() first.");
     }
-    return new this.#wasm.instance.vtkStandaloneSession();
+    if (this.#wasmInstance === null) {
+      throw new Error("The currently loaded VTK.wasm version does not support standalone mode");
+    }
+    return new this.#wasmInstance.vtkStandaloneSession();
   }
 
   /** Helper for handling API change */
   createStateDecorator() {
-    if (this.#wasm.instance) {
+    if (!this.#loaded) {
+      throw new Error("WASM module is not loaded yet. Call load() first.");
+    }
+    if (this.#wasmInstance !== null) {
       return convertToObj;
     }
     return convertToStr;
-  }
-
-  /**
-   * Generate a WebAssembly configuration object from a wasmLoader config.
-   * @param {*} config - wasmLoader config with 'rendering' and 'exec' keys.
-   * @returns wasmConfig object
-   */
-  #generateWasmConfig(config) {
-    let wasmConfig = {}
-    if (this.#wasmFile !== null) {
-      wasmConfig.locateFile = (fileName) => {
-        if (this.#wasmFile === null) {
-          throw new Error("WASM file unexpectedly transitioned to null");
-        }
-        if (fileName == this.#wasmFile.name) {
-          this.#wasm.url = URL.createObjectURL(new File([this.#wasmFile.buffer], this.#wasmFile.name, { type: "application/wasm" }));
-          return this.#wasm.url;
-        }
-        return new URL(fileName, import.meta.url).href;
-      };
-      wasmConfig.onRuntimeInitialized = () => {
-        // Free the object URL after runtime is initialized
-        URL.revokeObjectURL(this.#wasm.url);
-        this.#wasm.url = null;
-      };
-    }
-    if (config?.rendering === "webgpu") {
-      wasmConfig.preRun = [(module) => {
-        module.ENV.VTK_GRAPHICS_BACKEND = "WEBGPU";
-      }];
-    }
-    return wasmConfig;
   }
 }


### PR DESCRIPTION
- Restructured the `src` directory by creating a new `core` subdirectory to house shared utilities and modules.
- Moved common functionalities into the `core` directory to promote code reuse and maintainability.
- Added constants for rendering backends, execution modes, and file extensions in `core/constants.js`.
- Moved `createFuture` to `core/future.js`.
- Moved gzip bundle handling functions to `core/gzipBundle.js` for fetching and extracting files.
- Moved JavaScript to C++ name conversion utilities in `core/javaScriptCxxTranslators.js`.
- Moved a proxy system for VTK objects in `core/proxy.js` to manage property access and method invocation. This makes it possible for one to import "remote.js" without getting "standalone.js" imported transitively. It caused a unnecessary error in console about a script with id=vtk-wasm missing.
- Moved script loading functionality to `core/scriptLoader.js` for dynamic WASM module loading.
- Created a session factory in `core/sessionFactory.js` to create remote sessions with existing WASM instances.
- Added state conversion utilities in `core/stateDecorators.js` for handling object and string conversions.
- Implemented string operations in `core/stringOps.js` for path manipulation and HTML document checks.
- Updated `remote.js`, `standalone.js`, `viewer.js`, and `wasmLoader.js` to utilize the new core modules and improve code organization.