### PR TITLE
fix(remote): remove fallback render window size

### DIFF
--- a/src/remote.js
+++ b/src/remote.js
@@ -387,8 +387,10 @@ export class RemoteSession {
       // Bump local mtime and process states to reflect server state
       try {
         this.sceneManager.updateObjectsFromStates();
-        const [w, h] = this.renderWindowSizes[vtkId] || [10, 10];
-        this.sceneManager.setSize(vtkId, w, h);
+        if (vtkId in this.renderWindowSizes) {
+          const [w, h] = this.renderWindowSizes[vtkId];
+          this.sceneManager.setSize(vtkId, w, h);
+        }
 
         // Prevent state patching with new API
         if (bindCanvas && this.sceneManager.bindRenderWindow) {


### PR DESCRIPTION
If render window size has not been set, do not force resize it, as it defaults to a wrong size.

This fix tries to make https://github.com/Kitware/trame-vtklocal/pull/30 work.