### PR TITLE
do not decompress gzip file if it already decompressed

### DIFF
--- a/src/core/gzipBundle.js
+++ b/src/core/gzipBundle.js
@@ -1,6 +1,5 @@
 import untar from "js-untar";
 import { stripLeadingDotSlash } from "./stringOps.js";
-import { createFuture } from "./future.js";
 import { MODULE_JS_FILE_EXTENSION, WASM_FILE_EXTENSION } from "./constants.js";
 
 /**
@@ -17,23 +16,25 @@ export function isGzipBundle(url) {
  * @param {string} url 
  * @returns {Promise<ArrayBuffer>} The decompressed tar archive contents from the gzip bundle.
  */
-export function fetchGzipBundle(url) {
-  const { promise, resolve, reject } = createFuture();
-  fetch(url).then((response) => {
-    if (response.ok) {
-      const decompressedStream = response.body.pipeThrough(new DecompressionStream('gzip'));
-      const decompressionResponse = new Response(decompressedStream);
-      decompressionResponse
-        .blob()
-        .then((blob) => blob.arrayBuffer())
-        .then(resolve)
-        .catch(reject);
-    }
-    else {
-      reject(new Error(`Could not fetch gzip bundle from ${url} - response status: ${response.status}`));
-    }
-  }).catch(reject);
-  return promise;
+export async function fetchGzipBundle(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Could not fetch gzip bundle from ${url} - response status: ${response.status}`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const uint8View = new Uint8Array(arrayBuffer);
+
+  // Check if it's already decompressed by the browser/server.
+  // Gzip magic number: 0x1F 0x8B.
+  if (uint8View.length >= 2 && uint8View[0] === 0x1F && uint8View[1] === 0x8B) {
+    // If it is gzipped, decompress it using DecompressionStream.
+    const decompressedStream = new Response(arrayBuffer).body.pipeThrough(new DecompressionStream('gzip'));
+    return await new Response(decompressedStream).arrayBuffer();
+  }
+
+  // Not gzipped (already decompressed by server/browser).
+  return arrayBuffer;
 }
 
 /**
@@ -43,22 +44,15 @@ export function fetchGzipBundle(url) {
  * @param {string} wasmBaseName 
  * @returns {Promise<{js: {name: string, buffer: ArrayBufferLike}, wasm: {name: string, buffer: ArrayBufferLike}}>}
  */
-export function extractFilesFromGzipBundle(contents, config, wasmBaseName) {
-  const { promise, resolve, reject } = createFuture();
-  untar(contents)
-    .then((files) => {
-      const execModeSuffix = config?.exec === "async" ? "Async" : "";
-      const jsFileMatch = `${wasmBaseName}WebAssembly${execModeSuffix}${MODULE_JS_FILE_EXTENSION}`;
-      const wasmFileMatch = `${wasmBaseName}WebAssembly${execModeSuffix}${WASM_FILE_EXTENSION}`;
-      const jsFile = files.find((file) => stripLeadingDotSlash(file.name) === jsFileMatch);
-      const wasmFile = files.find((file) => stripLeadingDotSlash(file.name) === wasmFileMatch);
-      if (jsFile === undefined || wasmFile === undefined) {
-        reject(new Error(`Could not find expected files ${jsFileMatch} and ${wasmFileMatch} in the gzip bundle`));
-      }
-      else {
-        resolve({ js: jsFile, wasm: wasmFile });
-      }
-    })
-    .catch(reject);
-  return promise;
+export async function extractFilesFromGzipBundle(contents, config, wasmBaseName) {
+  const files = await untar(contents);
+  const execModeSuffix = config?.exec === "async" ? "Async" : "";
+  const jsFileMatch = `${wasmBaseName}WebAssembly${execModeSuffix}${MODULE_JS_FILE_EXTENSION}`;
+  const wasmFileMatch = `${wasmBaseName}WebAssembly${execModeSuffix}${WASM_FILE_EXTENSION}`;
+  const jsFile = files.find((file) => stripLeadingDotSlash(file.name) === jsFileMatch);
+  const wasmFile = files.find((file) => stripLeadingDotSlash(file.name) === wasmFileMatch);
+  if (jsFile === undefined || wasmFile === undefined) {
+    throw new Error(`Could not find expected files ${jsFileMatch} and ${wasmFileMatch} in the gzip bundle`);
+  }
+  return { js: jsFile, wasm: wasmFile };
 }


### PR DESCRIPTION
WHY THIS PR
When fetching the gzip bundle, certain server configurations return the asset with the Content-Encoding: gzip HTTP header. This prompts the browser to automatically decompress the response payload at the network layer before passing it to the JavaScript application