### PR TITLE
feat: make createNamespace sync by moving it into VtkWASMLoader

### DIFF
--- a/docs/guide/js/bundler.md
+++ b/docs/guide/js/bundler.md
@@ -4,7 +4,7 @@ Modern web development rely on package manager to bring project dependencies. Th
 
 ## Project setup
 
-In the simple example we are going to use [Vite](https://vite.dev/) with Vanilla JavaScript. The full code is available for reference [here](https://github.com/Kitware/vtk-wasm/tree/main/examples/js/simple-app).
+In the simple example we are going to use [Vite](https://vite.dev/) with Vanilla JavaScript. The full code is available for reference [here](https://github.com/Kitware/vtk-wasm/tree/main/examples/js/simple-app). Please note that you should use a concrete version, or "latest" for the `@kitware/vtk-wasm` package. Here, the example uses a relative path to the `vtk-wasm` project root, so the in-repo documentation stays relevant.
 
 ::: code-group
 <<< ../../../examples/js/simple-app/package.json

--- a/examples/js/simple-app/package-lock.json
+++ b/examples/js/simple-app/package-lock.json
@@ -19,6 +19,10 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@codemirror/lang-html": "^6.4.11",
+        "@codemirror/lang-javascript": "^6.2.4",
+        "@codemirror/theme-one-dark": "^6.1.3",
+        "codemirror": "^6.0.2",
         "js-untar": "^2.0.0",
         "jszip": "3.10.1"
       },
@@ -28,7 +32,7 @@
         "globals": "^16.0.0",
         "prettier": "3.5.3",
         "rimraf": "^6.0.1",
-        "semantic-release": "24.2.7",
+        "semantic-release": "25.0.2",
         "vite": "^6.2.4",
         "vitepress": "^1.6.3"
       }

--- a/examples/js/simple-app/package.json
+++ b/examples/js/simple-app/package.json
@@ -12,6 +12,6 @@
     "vite": "^6.3.5"
   },
   "dependencies": {
-    "@kitware/vtk-wasm": "latest"
+    "@kitware/vtk-wasm": "file:../../.."
   }
 }

--- a/examples/js/simple-app/src/main.js
+++ b/examples/js/simple-app/src/main.js
@@ -1,8 +1,8 @@
 import "./style.css";
-import { createNamespace } from "@kitware/vtk-wasm/vtk";
+import { VtkWASMLoader } from "@kitware/vtk-wasm/vtk";
 import { buildWASMScene } from "./example";
 
-const VTK_WASM_TARBALL_URL = "https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.5.20251215/vtk-9.5.20251215-wasm32-emscripten.tar.gz";
-createNamespace(VTK_WASM_TARBALL_URL).then((vtk) => {
-  buildWASMScene(vtk, "#app > canvas", "This scene passes the VTK.wasm bundle from GitLab registry to createNamespace()");
-});
+const loader = new VtkWASMLoader();
+await loader.load("https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.5.20251215/vtk-9.5.20251215-wasm32-emscripten.tar.gz");
+const vtk = loader.createNamespace();
+buildWASMScene(vtk, "#app > canvas", "This scene passes the VTK.wasm bundle from GitLab registry to createNamespace()");

--- a/examples/js/simple-app/vite.config.js
+++ b/examples/js/simple-app/vite.config.js
@@ -1,6 +1,7 @@
 export default {
   base: "./",
   build: {
+    target: "esnext",
     outDir: "../../../docs/public/demo/simple-app",
     emptyOutDir: true,
   },

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -1,6 +1,5 @@
-import { VtkWASMLoader } from "./wasmLoader";
+export { VtkWASMLoader } from "./wasmLoader";
 import { createFuture } from "./core/future";
-import { createInstantiatorProxy } from "./core/proxy";
 
 /**
  * Create a VTK namespace for handling vtk object creation.
@@ -13,14 +12,9 @@ import { createInstantiatorProxy } from "./core/proxy";
  * @returns the vtk namespace for creating VTK objects.
  */
 export async function createNamespace(url, config = {}, wasmBaseName = "vtk") {
-  const vtkProxyCache = new WeakMap();
-  const idToRef = new Map();
-
   const loader = new VtkWASMLoader();
   await loader.load(url || "loaded-module", config, wasmBaseName);
-  const wasm = loader.createStandaloneSession();
-
-  return createInstantiatorProxy(wasm, vtkProxyCache, idToRef);
+  return loader.createNamespace();
 }
 
 /**
@@ -33,18 +27,18 @@ export async function createNamespace(url, config = {}, wasmBaseName = "vtk") {
  *  - data-config="{ rendering: 'webgl|webgpu', exec: 'sync|async' }" json config for
  *    WASM module configuration.
  */
-const { promise, resolve, reject } = createFuture();
-const script = document.querySelector("#vtk-wasm");
-if (script) {
-  const url = script.dataset.url || ".";
-  const config = JSON.parse(script.dataset.config || "{}");
-  window.vtkReady = promise;
-  createNamespace(url, config)
-    .then((vtk) => {
-      window.vtk = vtk;
-      resolve(vtk);
-    })
-    .catch(reject);
-} else {
-  reject("Automatic VTK namespace initialization is disabled because no <script id=\"vtk-wasm\"> tag was found. See https://kitware.github.io/vtk-wasm/guide/js/plain.html#defer-wasm-loading-with-annotation'");
+if (typeof window !== "undefined") {
+  const script = document.querySelector("#vtk-wasm");
+  if (script) {
+    const { promise, resolve, reject } = createFuture();
+    const url = script.dataset.url || ".";
+    const config = JSON.parse(script.dataset.config || "{}");
+    window.vtkReady = promise;
+    createNamespace(url, config)
+      .then((vtk) => {
+        window.vtk = vtk;
+        resolve(vtk);
+      })
+      .catch(reject);
+  }
 }

--- a/src/wasmLoader.js
+++ b/src/wasmLoader.js
@@ -6,6 +6,7 @@ import { createRemoteSession } from "./core/sessionFactory";
 import { createFuture } from "./core/future";
 import { createBlobURL, disposeBlobURL } from "./core/blobURL";
 import { convertToObj, convertToStr } from "./core/stateDecorators";
+import { createInstantiatorProxy } from "./core/proxy";
 
 /**
  * VtkWASMLoader type definition
@@ -151,6 +152,18 @@ export class VtkWASMLoader {
     } else {
       await this.#pendingLoad;
     }
+  }
+
+  /**
+   * Create a vtk namespace for handling vtk object creation.
+   * This must be called after load() is complete. The returned namespace will be a proxy that creates VTK objects in the standalone session.
+   * @returns {Object} The vtk namespace for creating VTK objects.
+   */
+  createNamespace() {
+    const vtkProxyCache = new WeakMap();
+    const idToRef = new Map();
+    const wasm = this.createStandaloneSession();
+    return createInstantiatorProxy(wasm, vtkProxyCache, idToRef);
   }
 
   /**


### PR DESCRIPTION
- this allows one to first load a VTK.wasm binary, then create a namespace synchronously using said binary.
- see examples/js/simple-app/src/main.js for usage

```js
import { VtkWASMLoader } from "@kitware/vtk-wasm/vtk";
const loader = new VtkWASMLoader();
await loader.load(gzipURL);
const vtk = loader.createNamespace();
let renderWindow = vtk.vtkRenderWindow();
```

@ansbbrooks i tried making the createNamespace sync. I could not get `VtkWASMLoader.load` to be sync because it can fire off a `fetch`.