### PR TITLE
Remove wasm url extension check

### DIFF
--- a/src/core/gzipBundle.js
+++ b/src/core/gzipBundle.js
@@ -4,15 +4,6 @@ import { createFuture } from "./future.js";
 import { MODULE_JS_FILE_EXTENSION, WASM_FILE_EXTENSION } from "./constants.js";
 
 /**
- * Check if provided URL points to a gzip bundle
- * @param {string} url 
- * @returns {boolean}
- */
-export function isGzipBundle(url) {
-  return typeof url === "string" && url.endsWith(".gz");
-}
-
-/**
  * Fetch gzip bundle from provided URL
  * @param {string} url 
  * @returns {Promise<ArrayBuffer>} The decompressed tar archive contents from the gzip bundle.

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -11,7 +11,7 @@ import { createInstantiatorProxy } from "./core/proxy";
  * @param {Object} config
  * @param {string} [wasmBaseName] - (default is `"vtk"`) base name of the wasm bundle to load. e.g., `"vtk"` or `"addon"` will
  *                             look for vtkWebAssembly.mjs or addonWebAssembly.mjs in the wasmBaseURL.
- * @param {boolean} [urlIsGzipBundle] - (default is `true`) specifies whether the resource at `wasmBaseURL` is in Gzip format.
+ * @param {boolean} [urlIsGzipBundle] - (default is `true`) specifies whether the resource at `wasmBaseURL` is a Gzip archive.
  *
  * @returns the vtk namespace for creating VTK objects.
  */

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -9,15 +9,23 @@ import { createInstantiatorProxy } from "./core/proxy";
  *                  If vtkWebAssemblyInterface.mjs is already loaded as a script,
  *                  this will be ignored.
  * @param {Object} config
+ * @param {string} [wasmBaseName] - (default is `"vtk"`) base name of the wasm bundle to load. e.g., `"vtk"` or `"addon"` will
+ *                             look for vtkWebAssembly.mjs or addonWebAssembly.mjs in the wasmBaseURL.
+ * @param {boolean} [urlIsGzipBundle] - (default is `true`) specifies whether the resource at `wasmBaseURL` is in Gzip format.
  *
  * @returns the vtk namespace for creating VTK objects.
  */
-export async function createNamespace(url, config = {}, wasmBaseName = "vtk") {
+export async function createNamespace(
+    url,
+    config = {},
+    wasmBaseName = "vtk",
+    urlIsGzipBundle = true,
+) {
   const vtkProxyCache = new WeakMap();
   const idToRef = new Map();
 
   const loader = new VtkWASMLoader();
-  await loader.load(url || "loaded-module", config, wasmBaseName);
+  await loader.load(url || "loaded-module", config, wasmBaseName, urlIsGzipBundle);
   const wasm = loader.createStandaloneSession();
 
   return createInstantiatorProxy(wasm, vtkProxyCache, idToRef);

--- a/src/wasmLoader.js
+++ b/src/wasmLoader.js
@@ -1,4 +1,4 @@
-import { extractFilesFromGzipBundle, fetchGzipBundle, isGzipBundle } from "./core/gzipBundle";
+import { extractFilesFromGzipBundle, fetchGzipBundle } from "./core/gzipBundle";
 import { createEmscriptenConfig, normalizeConfig, validateConfig } from "./core/configManager";
 import { DEFAULT_CONFIG, MIME_TYPES } from "./core/constants";
 import { createScriptURL, loadWebAssemblyModuleFromExistingScript, loadWebAssemblyModuleFromScript } from "./core/scriptLoader";
@@ -41,13 +41,15 @@ export class VtkWASMLoader {
    *
    * @param {string} wasmBaseURL
    * @param {object} config - for WASM runtime creation.
-   * @param {string} wasmBaseName - (default is "vtk") base name of the wasm bundle to load. e.g., "vtk" or "addon" will
+   * @param {string} wasmBaseName - (default is `"vtk"`) base name of the wasm bundle to load. e.g., `"vtk"` or `"addon"` will
    *                             look for vtkWebAssembly.mjs or addonWebAssembly.mjs in the wasmBaseURL.
+   * @param {boolean} [urlIsGzipBundle] - (default is `true`) specifies whether the resource at `wasmBaseURL` is in Gzip format.
    */
   async load(
     wasmBaseURL,
     config = DEFAULT_CONFIG,
     wasmBaseName = "vtk",
+    urlIsGzipBundle = true,
   ) {
     if (this.#loaded) {
       return;
@@ -66,7 +68,7 @@ export class VtkWASMLoader {
 
       let wasmFile = null;
       if (!window.createVTKWASM) {
-        if (isGzipBundle(wasmBaseURL)) {
+        if (urlIsGzipBundle) {
           let gzipArrayBuffer;
           let javaScriptBlobURL = null;
           try {

--- a/src/wasmLoader.js
+++ b/src/wasmLoader.js
@@ -43,7 +43,7 @@ export class VtkWASMLoader {
    * @param {object} config - for WASM runtime creation.
    * @param {string} wasmBaseName - (default is `"vtk"`) base name of the wasm bundle to load. e.g., `"vtk"` or `"addon"` will
    *                             look for vtkWebAssembly.mjs or addonWebAssembly.mjs in the wasmBaseURL.
-   * @param {boolean} [urlIsGzipBundle] - (default is `true`) specifies whether the resource at `wasmBaseURL` is in Gzip format.
+   * @param {boolean} [urlIsGzipBundle] - (default is `true`) specifies whether the resource at `wasmBaseURL` is a Gzip archive.
    */
   async load(
     wasmBaseURL,


### PR DESCRIPTION
Currently, when a wasm url is passed to `createNamespace()`, `loader.load()` checks if the url ends with `.gz` to handle Gzip archives.

This is a problem since urls do not have to have a `.gz` extension to serve a Gzip file.

For example, running a server that serves the VTK.wasm client `.gz` bundle at the following endpoint would fail the url check:

```
http://localhost/get_vtk_bundle
```

It is better to allow the Gzip decompressor to fail on its own if the downloaded resource is not a Gzip archive, and let the user specify what is at the end of their endpoint (since only they can know for sure).

In this PR, the `createNamespace()` function has the following signature:

```ts
createNamespace(url: string, config: object, wasmBaseName: string, urlIsGzipBundle: boolean)
```