### PR TITLE
Use explicit `import` and `export` of `VtkWASMLoader`

### DIFF
--- a/src/standalone.js
+++ b/src/standalone.js
@@ -1,5 +1,6 @@
-export { VtkWASMLoader } from "./wasmLoader";
 import { createFuture } from "./core/future";
+import { VtkWASMLoader } from "./wasmLoader";
+export { VtkWASMLoader };
 
 /**
  * Create a VTK namespace for handling vtk object creation.


### PR DESCRIPTION
Currently, `VtkWASMLoader` is exported from `standalone.js`, but it is also used in `standalone.js` with no `import` statement.

Some JS Bundlers may detect that `VtkWASMLoader` is not imported, and add an `import` statement for you automatically, but it's not guaranteed.

In a normal JS environment, using an object when it's not explicitly imported will throw an error.

This PR ensures that `VtkWASMLoader` is explicitly imported as well as exported.