### PR TITLE
chore(guide): bump vtk-wasm bundle to 9.6.20260621

### DIFF
--- a/docs/guide/js/loading.md
+++ b/docs/guide/js/loading.md
@@ -29,7 +29,7 @@ flowchart TD
 import { loadAsync } from "@kitware/vtk-wasm";
 
 const runtime = await loadAsync({
-  url: "https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz",
+  url: "https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260621/vtk-9.6.20260621-wasm32-emscripten.tar.gz",
 });
 ```
 

--- a/docs/guide/js/primer.md
+++ b/docs/guide/js/primer.md
@@ -15,7 +15,7 @@ Start by instantiating the class you need from the `vtk` namespace.
         <script
             src="https://unpkg.com/@kitware/vtk-wasm/vtk-umd.js"
             id="vtk-wasm"
-            data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz">
+            data-url="https://raw.githack.com/Kitware/vtk-wasm/dist/latest/vtk-wasm32-emscripten.tar.gz">
         </script>
     </head>
     <body>
@@ -37,7 +37,7 @@ Once you have an object, inspection usually comes next. Use `toString()` to invo
         <script
             src="https://unpkg.com/@kitware/vtk-wasm/vtk-umd.js"
             id="vtk-wasm"
-            data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz">
+            data-url="https://raw.githack.com/Kitware/vtk-wasm/dist/latest/vtk-wasm32-emscripten.tar.gz">
         </script>
     </head>
     <body>
@@ -86,7 +86,7 @@ Object properties can be read and assigned with standard `.` notation.
         <script
             src="https://unpkg.com/@kitware/vtk-wasm/vtk-umd.js"
             id="vtk-wasm"
-            data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz">
+            data-url="https://raw.githack.com/Kitware/vtk-wasm/dist/latest/vtk-wasm32-emscripten.tar.gz">
         </script>
     </head>
     <body>
@@ -110,7 +110,7 @@ Member functions are also accessed with `.` notation. These calls return `Promis
         <script
             src="https://unpkg.com/@kitware/vtk-wasm/vtk-umd.js"
             id="vtk-wasm"
-            data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz">
+            data-url="https://raw.githack.com/Kitware/vtk-wasm/dist/latest/vtk-wasm32-emscripten.tar.gz">
         </script>
     </head>
     <body>
@@ -138,7 +138,7 @@ The same object model extends to method arguments. When an API expects another V
         <script
             src="https://unpkg.com/@kitware/vtk-wasm/vtk-umd.js"
             id="vtk-wasm"
-            data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz">
+            data-url="https://raw.githack.com/Kitware/vtk-wasm/dist/latest/vtk-wasm32-emscripten.tar.gz">
         </script>
     </head>
     <body>
@@ -165,7 +165,7 @@ When an object is no longer needed, call `delete()` to release its external Java
         <script
             src="https://unpkg.com/@kitware/vtk-wasm/vtk-umd.js"
             id="vtk-wasm"
-            data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz">
+            data-url="https://raw.githack.com/Kitware/vtk-wasm/dist/latest/vtk-wasm32-emscripten.tar.gz">
         </script>
     </head>
     <body>
@@ -191,7 +191,7 @@ VTK provides array classes for typed data exchange. These arrays accept JavaScri
         <script
             src="https://unpkg.com/@kitware/vtk-wasm/vtk-umd.js"
             id="vtk-wasm"
-            data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz">
+            data-url="https://raw.githack.com/Kitware/vtk-wasm/dist/latest/vtk-wasm32-emscripten.tar.gz">
         </script>
     </head>
     <body>
@@ -217,7 +217,7 @@ In addition to VTK-managed state, you can attach custom JavaScript properties to
         <script
             src="https://unpkg.com/@kitware/vtk-wasm/vtk-umd.js"
             id="vtk-wasm"
-            data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz">
+            data-url="https://raw.githack.com/Kitware/vtk-wasm/dist/latest/vtk-wasm32-emscripten.tar.gz">
         </script>
     </head>
     <body>
@@ -242,7 +242,7 @@ For interactive workflows, register event handlers with `observe()`. Remove a ha
         <script
             src="https://unpkg.com/@kitware/vtk-wasm/vtk-umd.js"
             id="vtk-wasm"
-            data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz">
+            data-url="https://raw.githack.com/Kitware/vtk-wasm/dist/latest/vtk-wasm32-emscripten.tar.gz">
         </script>
     </head>
     <body>
@@ -279,7 +279,7 @@ Create a canvas in your HTML and ensure that you assign the `id` of the canvas t
     <script
       src="https://unpkg.com/@kitware/vtk-wasm/vtk-umd.js"
       id="vtk-wasm"
-      data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz"></script>
+      data-url="https://raw.githack.com/Kitware/vtk-wasm/dist/latest/vtk-wasm32-emscripten.tar.gz"></script>
   </head>
   <body>
     <div style="min-height:300px">

--- a/docs/guide/js/remote-session.md
+++ b/docs/guide/js/remote-session.md
@@ -57,7 +57,7 @@ The state objects mirror what `vtklocal.get.state` returns: each carries an `Id`
 </html></textarea>
     <pre data-lang="js" style="display:none">
 const runtime = await vtkwasm.loadAsync({
-  url: "https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz",
+  url: "https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260621/vtk-9.6.20260621-wasm32-emscripten.tar.gz",
 });
 const remote = runtime.createRemoteSession();
 // The "server": 

--- a/docs/public/demo/plain-javascript-annotation-wasm-registry.html
+++ b/docs/public/demo/plain-javascript-annotation-wasm-registry.html
@@ -3,7 +3,7 @@
     <script
       src="https://unpkg.com/@kitware/vtk-wasm/vtk-umd.js"
       id="vtk-wasm"
-      data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260228/vtk-9.6.20260228-wasm32-emscripten.tar.gz"
+      data-url="https://gitlab.kitware.com/api/v4/projects/13/packages/generic/vtk-wasm32-emscripten/9.6.20260621/vtk-9.6.20260621-wasm32-emscripten.tar.gz"
     ></script>
     <script src="example.js"></script>
   </head>


### PR DESCRIPTION
Only one example shows errors:

```js
const vtk = await vtkwasm.ready;
const coordinates = vtk.vtkTypeFloat64Array();
coordinates.number_of_components = 3;
await coordinates.SetArray(new Float64Array([-1, -1, 0, 1, -1, 0]));
console.log(await coordinates.GetTuple1(0));
```

Errors:

```
2026-06-22 09:43:19.942 (   0.001s) [          939654]      vtkSerializer.cxx:86     ERR| vtkSerializer (0x95f4c8): Failed to serialize objectBase=vtkTypeFloat64Array (0x98c258). message=[json.exception.out_of_range.403] key 'MTime' not found
2026-06-22 09:43:19.942 (   0.002s) [          939654]   vtkObjectManager.cxx:885    ERR| vtkObjectManager (0x95f3e0): Failed to update state for object at id=1
2026-06-22 09:43:19.942 (   0.002s) [          939654]      vtkSerializer.cxx:86     ERR| vtkSerializer (0x95f4c8): Failed to serialize objectBase=vtkTypeFloat64Array (0x98c258). message=[json.exception.out_of_range.403] key 'MTime' not found
2026-06-22 09:43:19.942 (   0.002s) [          939654]   vtkObjectManager.cxx:885    ERR| vtkObjectManager (0x95f3e0): Failed to update state for object at id=1
-1
```

Will create issue separately to track bugfix for that.