### PR TITLE
feat(js): expose readonly `disposed` property on standalone and remote sessions

### DIFF
--- a/src/remoteSession.js
+++ b/src/remoteSession.js
@@ -514,6 +514,13 @@ export class RemoteSession {
   }
 
   /**
+   * @returns {boolean}
+   */
+  get disposed(){
+    return this.#disposed;
+  }
+
+  /**
    * Free the C++ session and detach the interaction listeners installed on the
    * user-provided canvases. The canvas elements themselves are left untouched.
    * The session is unusable afterwards.

--- a/src/standaloneSession.js
+++ b/src/standaloneSession.js
@@ -30,6 +30,13 @@ export class StandaloneSession {
   }
 
   /**
+   * @returns {boolean}
+   */
+  get disposed(){
+    return this.#disposed;
+  }
+
+  /**
    * Free the C++ session and all objects it owns, and drop proxy caches.
    * The session is unusable afterwards.
    */


### PR DESCRIPTION
This PR exposes a readonly `disposed` property on `StandaloneSession` and `RemoteSession`.

@jspanchu @jourdain 