### PR TITLE
Fixing webgpu

### DIFF
--- a/src/core/configManager.js
+++ b/src/core/configManager.js
@@ -69,7 +69,7 @@ export function createEmscriptenConfig(config, wasmFile) {
       ? config.preRun
       : (config?.preRun ? [config.preRun] : []);
     emscriptenConfig.preRun = [(module) => {
-      module.ENV.VTK_GRAPHICS_BACKEND = 'WEBGPU';
+      module.ENV.VTK_FACTORY_PREFER = 'RenderingBackend=WebGPU';
     },
     ...userPreRun];
   }

--- a/src/core/scriptLoader.js
+++ b/src/core/scriptLoader.js
@@ -2,74 +2,6 @@ import { createFuture } from "./future";
 import { isHTMLDocument } from "./stringOps";
 import { MODULE_JS_FILE_EXTENSION } from "./constants";
 
-const LOADED_URLS = [];
-const PROMISES = {};
-
-/**
- * Wait for existing wasm script to be loaded.
- * This is useful when the script tag with a path to the wasm module already
- * exists in the HTML document.
- * 
- * @param {string} wasmBaseName 
- * @returns {Promise<void>}
- */
-export function loadWebAssemblyModuleFromExistingScriptAsync(wasmBaseName) {
-  if (window.createVTKWASM) {
-    return Promise.resolve();
-  }
-
-  let scriptPromise = null;
-  const scriptName = `${wasmBaseName}WebAssembly`;
-  const scripts = document.querySelectorAll("script");
-  for (const script of scripts) {
-    if (script.src.includes(scriptName)) {
-      const { promise, resolve, reject } = createFuture();
-      script.onload = resolve;
-      script.onerror = () => {
-        reject(new Error(`Failed to load script: ${script.src}`));
-      };
-      scriptPromise = promise;
-      break;
-    }
-  }
-  if (scriptPromise) {
-    return scriptPromise;
-  } else {
-    return Promise.resolve();
-  }
-}
-
-/**
- * Add script tag with provided URL with type="module"
- *
- * @param {string} url a URL to the wasm module JavaScript file
- * @return {Promise<void>} to know when the script is ready
- */
-export function loadWebAssemblyModuleFromScriptAsync(url) {
-  if (PROMISES[url]) {
-    return PROMISES[url];
-  }
-
-  PROMISES[url] = new Promise(function (resolve, reject) {
-    if (LOADED_URLS.indexOf(url) === -1) {
-      LOADED_URLS.push(url);
-      const newScriptTag = document.createElement("script");
-      newScriptTag.type = "module";
-      newScriptTag.src = url;
-      newScriptTag.onload = resolve;
-      newScriptTag.onerror = () => {
-        reject(new Error(`Failed to load script: ${url}`));
-      };
-      document.body.appendChild(newScriptTag);
-    } else {
-      // Already loaded.
-      resolve(false);
-    }
-  });
-
-  return PROMISES[url];
-}
-
 /**
  * Get the URL of the WebAssembly module JavaScript file. This is the glue
  * code that loads the WebAssembly binary. It tries to fetch the file to
@@ -77,15 +9,27 @@ export function loadWebAssemblyModuleFromScriptAsync(url) {
  *
  * This is a fallback when not using GZIP bundles.
  *
+ * The returned URL is resolved to an absolute URL against the document base so
+ * it can be handed to a dynamic `import()`. Unlike `fetch()`, `import()` does
+ * not resolve relative specifiers against the page origin (a bare specifier
+ * like "vtk/wasm/vtkWebAssembly.mjs" would throw, and a "./"-relative one would
+ * resolve against the bundle's location, not the page). Resolving here keeps a
+ * relative `wasmBaseURL` (e.g. "myapp/wasm32/9.6.0") pointing at the page
+ * origin, exactly as the prior `fetch`-based loader did. Absolute `wasmBaseURL`
+ * values pass through unchanged.
+ *
  * @param {string} wasmBaseURL URL where the wasm module JavaScript file is located
  * @param {string} wasmBaseName Base name of the wasm module JavaScript file
  * @param {object} config Configuration object
- * @returns {Promise<string>} URL of the wasm module JavaScript file
+ * @returns {Promise<string>} Absolute URL of the wasm module JavaScript file
  */
 export async function createScriptURLAsync(wasmBaseURL, wasmBaseName, config) {
   const execModeSuffix = config?.exec === "async" ? "Async" : "";
   const filename = `${wasmBaseName}WebAssembly${execModeSuffix}${MODULE_JS_FILE_EXTENSION}`;
-  const url = `${wasmBaseURL}/${filename}`;
+  // Strip trailing slashes
+  wasmBaseURL = String(wasmBaseURL).replace(/\/+$/, "");
+  const base = typeof document !== "undefined" ? document.baseURI : undefined;
+  const url = new URL(`${wasmBaseURL}/${filename}`, base).href;
   const { promise, resolve, reject } = createFuture();
   fetch(url)
     .then((response) => {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,7 +1,7 @@
 import { extractFilesFromGzipBundleAsync, fetchGzipBundleAsync } from "./core/gzipBundle";
 import { createEmscriptenConfig, normalizeConfig, validateConfig } from "./core/configManager";
 import { DEFAULT_CONFIG, DEFAULT_WASM_BASE_NAME, DEFAULT_WASM_URL_IS_GZIP, MIME_TYPES } from "./core/constants";
-import { createScriptURLAsync, loadWebAssemblyModuleFromExistingScriptAsync, loadWebAssemblyModuleFromScriptAsync } from "./core/scriptLoader";
+import { createScriptURLAsync } from "./core/scriptLoader";
 import { createBlobURL, disposeBlobURL } from "./core/blobURL";
 import { StandaloneSession } from "./standaloneSession";
 import { RemoteSession } from "./remoteSession";
@@ -43,57 +43,87 @@ function exposeSpecialHTMLTargets(buffer) {
 }
 
 /**
- * Ensure `window.createVTKWASM` is available, loading the glue script if needed.
- * Returns the wasm binary descriptor when it had to be extracted from a gzip
- * bundle (so it can be handed to Emscripten), otherwise null.
+ * Dynamically import the Emscripten glue module and return its default export.
+ * sync (`...WebAssembly.mjs`) and async (`...WebAssemblyAsync.mjs`) glue modules
+ * resolve to distinct factories and never collide on a shared global.
+ *
+ * @param {string} moduleURL - URL (or blob URL) of the glue `.mjs` module.
+ * @returns {Promise<Function>} the module factory.
  */
-async function prepareModuleFactoryAsync(url, urlIsGzip, wasmBaseName, config) {
-  if (!window.createVTKWASM) {
-    await loadWebAssemblyModuleFromExistingScriptAsync(wasmBaseName);
+async function importModuleFactoryAsync(moduleURL) {
+  let namespace;
+  try {
+    // @vite-ignore keeps this a true runtime dynamic import (the URL is a
+    // variable / blob URL that Vite must not try to statically resolve).
+    namespace = await import(/* @vite-ignore */ moduleURL);
+  } catch (cause) {
+    throw new Error(
+      [
+        `Could not import the WebAssembly glue module from "${moduleURL}".`,
+        "Possible causes include:",
+        "  - Incorrect or unreachable 'url'",
+        "  - Wrong 'wasmBaseName' or missing/misnamed .mjs/.wasm files in the bundle",
+        "  - Network or script loading failures (e.g., 404/500 responses)",
+        "  - Content Security Policy (CSP) blocking module execution",
+        "",
+        "Next steps:",
+        "  - Verify that the expected .mjs and .wasm files are present and accessible under 'url'",
+        "  - Check the browser's Network/Console tabs for failed module requests or CSP errors.",
+      ].join("\n"),
+      { cause },
+    );
   }
-  if (window.createVTKWASM) {
-    return null;
+  const factory = namespace?.default;
+  if (typeof factory !== "function") {
+    throw new Error(
+      `The module at "${moduleURL}" did not provide a default export factory function.`,
+    );
   }
+  return factory;
+}
 
+/**
+ * Resolve the glue module factory and the wasm binary descriptor (if any) for
+ * the requested configuration. Returns `{ factory, wasmFile }`, where
+ * `wasmFile` is non-null only when the binary had to be extracted from a gzip
+ * bundle (so it can be handed to Emscripten).
+ */
+async function loadModuleFactoryAsync(url, urlIsGzip, wasmBaseName, config) {
   if (urlIsGzip) {
     const gzipArrayBuffer = await fetchGzipBundleAsync(url);
     const { js, wasm } = await extractFilesFromGzipBundleAsync(gzipArrayBuffer, config, wasmBaseName);
     const javaScriptBlobURL = createBlobURL(exposeSpecialHTMLTargets(js.buffer), MIME_TYPES.JAVASCRIPT);
     try {
-      await loadWebAssemblyModuleFromScriptAsync(javaScriptBlobURL);
+      const factory = await importModuleFactoryAsync(javaScriptBlobURL);
+      return { factory, wasmFile: wasm };
     } finally {
+      // Safe to revoke now: the module is fully evaluated once import() resolves.
       disposeBlobURL(javaScriptBlobURL);
     }
-    return wasm;
   }
 
   const scriptURL = await createScriptURLAsync(url, wasmBaseName, config);
-  if (scriptURL !== null) {
-    await loadWebAssemblyModuleFromScriptAsync(scriptURL);
+  if (scriptURL === null) {
+    const execModeSuffix = config?.exec === "async" ? "Async" : "";
+    throw new Error(
+      [
+        `Could not locate the WebAssembly glue module for '${wasmBaseName}WebAssembly${execModeSuffix}.mjs' under "${url}".`,
+        "The file was missing, returned a non-OK response, or the server replied with an HTML document.",
+        "",
+        "Next steps:",
+        "  - Verify that the expected .mjs and .wasm files are present and accessible under 'url'",
+        "  - Check the browser's Network/Console tabs for failed module requests or CSP errors.",
+      ].join("\n"),
+    );
   }
-  return null;
+  const factory = await importModuleFactoryAsync(scriptURL);
+  return { factory, wasmFile: null };
 }
 
 async function instantiateAsync(url, urlIsGzip, wasmBaseName, config, key) {
   try {
-    const wasmFile = await prepareModuleFactoryAsync(url, urlIsGzip, wasmBaseName, config);
-    if (!window.createVTKWASM) {
-      throw new Error(
-        [
-          "Could not load WebAssembly module: window.createVTKWASM is not available after loading scripts.",
-          "Possible causes include:",
-          `  - Incorrect or unreachable 'url' ("${url}")`,
-          `  - Wrong 'wasmBaseName' ("${wasmBaseName}") or missing/misnamed .mjs/.wasm files in the bundle`,
-          "  - Network or script loading failures (e.g., 404/500 responses)",
-          "  - Content Security Policy (CSP) blocking script execution",
-          "",
-          "Next steps:",
-          "  - Verify that the expected .mjs and .wasm files are present and accessible under 'url'",
-          "  - Check the browser's Network/Console tabs for failed script requests or CSP errors.",
-        ].join("\n"),
-      );
-    }
-    const module = await window.createVTKWASM(createEmscriptenConfig(config, wasmFile));
+    const { factory, wasmFile } = await loadModuleFactoryAsync(url, urlIsGzip, wasmBaseName, config);
+    const module = await factory(createEmscriptenConfig(config, wasmFile));
     const runtime = new VtkWasmRuntime(module, key);
     RUNTIME_CACHE.set(key, runtime);
     return runtime;


### PR DESCRIPTION
This still does not work because VTK wasm does not appear to be respecting the VTK_FACTORY_PREFER flag, among other issues:

1. When given a class like `vtkOpenGLRenderer` and `VTK_FACTORY_PREFER` is set to use webgpu, it is still not creating `vtkWebGPURenderer`. This is tracked in https://gitlab.kitware.com/vtk/vtk/-/work_items/20101
2. In VTK, when webgpu is used, the canvas selector must be set on the render window's `vtkHardwareWindow`. Without it, the webgpu surface failed to create.
