### PR TITLE
fix(runtime): add webpack and turbopack ignore pragmas to dynamic import

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -56,9 +56,14 @@ function exposeSpecialHTMLTargets(buffer) {
 async function importModuleFactoryAsync(moduleURL) {
   let namespace;
   try {
-    // @vite-ignore keeps this a true runtime dynamic import (the URL is a
-    // variable / blob URL that Vite must not try to statically resolve).
-    namespace = await import(/* @vite-ignore */ moduleURL);
+    // Keep this a true runtime dynamic import: the URL is a variable / blob URL
+    // that a bundler must not try to statically resolve. Each bundler has its
+    // own pragma, and they do not recognise each other's -- webpack and
+    // Turbopack rewrite the import into a thrown MODULE_NOT_FOUND when only
+    // @vite-ignore is present, so the glue module is never requested at all.
+    namespace = await import(
+      /* @vite-ignore */ /* webpackIgnore: true */ /* turbopackIgnore: true */ moduleURL
+    );
   } catch (cause) {
     throw new Error(
       [


### PR DESCRIPTION
`@vite-ignore` only means something to Vite. webpack and Turbopack rewrite the
dynamic import in `importModuleFactoryAsync`, so the glue module never gets
requested at all.

Under Next.js 16 (Turbopack) the call compiles to this:

```js
t = await Promise.resolve().then(() => {
  let e = Error("Cannot find module as expression is too dynamic");
  throw e.code = "MODULE_NOT_FOUND", e
})
```

`moduleURL` is gone entirely, so the error handler below blames the URL, the
MIME type or CSP — none of which are the problem. The file is served fine, and
importing the same URL by hand from page scope works.

Adding the webpack/Turbopack pragmas leaves the import alone:

```js
t = await import(e)
```

I also checked the pragmas make it through the Rollup build into `dist/`.
`npm run build` and `npm run lint` pass.
